### PR TITLE
[n8n]: fix malformed deep search outputSchema and contents endpoint nesting

### DIFF
--- a/nodes/Exa/Exa.node.ts
+++ b/nodes/Exa/Exa.node.ts
@@ -462,10 +462,19 @@ export class Exa implements INodeType {
 					rows: 3,
 				},
 				routing: {
-					request: {
-						body: {
-							outputDescription: '={{ $value || undefined }}',
-						},
+					send: {
+						preSend: [
+							async function (this, requestOptions) {
+								const desc = this.getNodeParameter('outputDescription', 0) as string;
+								if (desc) {
+									requestOptions.body = {
+										...(requestOptions.body as object),
+										outputSchema: { type: 'text', description: desc },
+									};
+								}
+								return requestOptions;
+							},
+						],
 					},
 				},
 			},
@@ -482,12 +491,22 @@ export class Exa implements INodeType {
 					},
 				},
 				default: '',
-				description: 'JSON Schema defining the structure of the output object',
+				description: 'JSON Schema defining the structure of the output object (provide properties/required, type:object is added automatically)',
 				routing: {
-					request: {
-						body: {
-							outputSchema: '={{ JSON.parse($value) }}',
-						},
+					send: {
+						preSend: [
+							async function (this, requestOptions) {
+								const raw = this.getNodeParameter('outputSchema', 0) as string;
+								if (raw) {
+									const parsed = JSON.parse(raw) as Record<string, unknown>;
+									requestOptions.body = {
+										...(requestOptions.body as object),
+										outputSchema: { type: 'object', ...parsed },
+									};
+								}
+								return requestOptions;
+							},
+						],
 					},
 				},
 			},
@@ -1069,12 +1088,22 @@ export class Exa implements INodeType {
 									contents.extras = extras;
 								}
 
-								if (Object.keys(contents).length > 0) {
-									requestOptions.body = {
-										...(requestOptions.body as object),
-										contents,
-									};
-								}
+									if (Object.keys(contents).length > 0) {
+										const resource = this.getNodeParameter('resource', 0) as string;
+										if (resource === 'contents') {
+											// /contents endpoint expects options at top level
+											requestOptions.body = {
+												...(requestOptions.body as object),
+												...contents,
+											};
+										} else {
+											// /search and /findSimilar nest under contents
+											requestOptions.body = {
+												...(requestOptions.body as object),
+												contents,
+											};
+										}
+									}
 
 								return requestOptions;
 							},


### PR DESCRIPTION
## Summary

Fixes three malformed API request issues found by auditing the n8n node against Vulcan's actual request schemas:

1. **Deep search text output**: Was sending `outputDescription` as a top-level body field, which Vulcan ignores. Now correctly sends `outputSchema: { type: "text", description: "..." }` per the `DeepV3OutputSchemaSchema` discriminated union.

2. **Deep search structured output**: Was sending `outputSchema: <raw user JSON>`, missing the required discriminator. Now wraps as `outputSchema: { type: "object", ...userSchema }` so properties/required pass through correctly.

3. **Contents endpoint (`/contents`)**: Was always nesting content options under `contents: { text, highlights, ... }`, but `ContentsPostRequestSchema` uses `.and(ContentsOptionsSchema)` which expects those fields at the top level. Now spreads flat for `/contents` and still nests for `/search` and `/findSimilar`.

## Review & Testing Checklist for Human

- [ ] **Verify the structured outputSchema spread order**: `{ type: 'object', ...parsed }` means a user-provided `type` key in their JSON would override `'object'`. Confirm this is acceptable (the API rejects non-`object` types anyway, but worth a thought).
- [ ] **Test deep search text output** with the exact request from the bug report: `{"query":"testing exa how","type":"deep","outputDescription":"verbose with citations inline\n","numResults":10}` — after the fix this should become `outputSchema: { type: "text", description: "verbose with citations inline\n" }` in the actual request body.
- [ ] **Test `/contents` endpoint** in n8n with content options (e.g. text=true) and verify the options are applied (not silently dropped by zod stripping the unknown `contents` key).
- [ ] **Test `/search` with contents options** still works (nested under `contents` key as before).

### Notes
- The answer endpoint's `outputSchema` (`answerOptions`) is intentionally left as `JSON.parse($value)` — the `/answer` API uses a flat `z.record()`, not the discriminated union.
- Indentation in the contents nesting block gained an extra level — cosmetic only, no logic impact.

Link to Devin session: https://app.devin.ai/sessions/e2b20fe7ab6746d5ba11dccd52a32859
Requested by: @JakubHojsan